### PR TITLE
Slackbot only echoes questions back to user

### DIFF
--- a/echo_q_robot.py
+++ b/echo_q_robot.py
@@ -27,11 +27,8 @@ def message(payload):
     text = event.get('text')
     
     if BOT_ID != user_id: 
-        if user_id in message_counts: 
-            message_counts[user_id] += 1
-        else: 
-            message_counts[user_id] = 1
-        client.chat_postMessage(channel=channel_id, text=text)
+        if  text.endswith('?'):
+            client.chat_postMessage(channel=channel_id, text=text)
 
 @app.route('/message-count', methods=['POST'])
 def message_count(): 


### PR DESCRIPTION
**Description: **
Slackbot can now only echo questions back to the user and will ignore regular text. Message count command is removed.